### PR TITLE
Check distance and friend-ness once

### DIFF
--- a/scripts/manager_effect_aura.lua
+++ b/scripts/manager_effect_aura.lua
@@ -377,33 +377,6 @@ local function addAuraEffect(auraType, effect, targetNode, sourceNode)
 	end
 end
 
-local function checkRange(nRange, nodeSource, nodeTarget)
-	local sourceToken = CombatManager.getTokenFromCT(nodeSource);
-	local targetToken = CombatManager.getTokenFromCT(nodeTarget);
-	if not sourceToken or not targetToken then
-		return false;
-	end;
-	local nDistanceBetweenTokens = Token.getDistanceBetween(sourceToken, targetToken)
-
-	if nDistanceBetweenTokens and nRange then
-		-- Debug.chat(nDistanceBetweenTokens, nRange)
-		return nDistanceBetweenTokens <= nRange;
-	end
-end
-
-local function addOrRemoveAura(nRange, auraType, targetNode, sourceNode, nodeEffect)
-	local existingAuraEffect = checkAuraAlreadyEffecting(sourceNode, targetNode, nodeEffect);
-	if checkRange(nRange, targetNode, sourceNode) then
-		if not existingAuraEffect then
-			addAuraEffect(auraType, nodeEffect, targetNode, sourceNode);
-		end
-	else
-		if existingAuraEffect then
-			removeAuraEffect(auraType, existingAuraEffect);
-		end
-	end
-end
-
 function checkAuraApplicationAndAddOrRemove(sourceNode, targetNode, auraEffect, nodeInfo)
 	if not targetNode or not auraEffect then
 		return nil

--- a/scripts/manager_effect_aura.lua
+++ b/scripts/manager_effect_aura.lua
@@ -379,14 +379,14 @@ end
 
 function checkAuraApplicationAndAddOrRemove(sourceNode, targetNode, auraEffect, nodeInfo)
 	if not targetNode or not auraEffect then
-		return nil
+		return false
 	end
 
 	if not sourceNode then
 		local sSource = DB.getValue(auraEffect, "source_name", "")
 		sourceNode = DB.findNode(sSource)
 		if not sourceNode then
-			return nil
+			return false
 		end
 	end
 
@@ -395,7 +395,7 @@ function checkAuraApplicationAndAddOrRemove(sourceNode, targetNode, auraEffect, 
 	if nRange then
 		nRange = math.floor(tonumber(nRange))
 	else
-		return nil
+		return false
 	end
 	if not auraType then
 		auraType = "all"


### PR DESCRIPTION
Based on a conversation we had on the Fantasy Grounds forms I realized we were calling `Token.getDistanceBetween` for every aura a character had. With this change we now store the distance & friend-ness of 2 tokens reducing the number of calls when there is more than 1 aura between them. I'm able to do this because tables in lua are passed by reference, so value of `local nodeInfo` persists between invocations of `checkAuraApplicationAndAddOrRemove`

In total with this change we should only call `Token.getDistanceBetween` and query the friend-ness once per combatant in the combat tracker.