### PR TITLE
Client side distance calculation

### DIFF
--- a/extension.xml
+++ b/extension.xml
@@ -2,7 +2,7 @@
 <root version="3.3" >
 	<properties>
 		<name>Aura Effects</name>
-		<version>0.10</version>
+		<version>1.0</version>
 		<author>Kent McCullough</author>
 		<description>Adds and removes effects based on proximity.</description>
 		<loadorder>999</loadorder>
@@ -20,7 +20,7 @@
 		</ruleset>
 	</properties>
 	
-	<announcement text="Aura Effects - Extension v0.10\r--by Kent McCullough 2020 updated by SoxMax and bmos" font="emotefont" />
+	<announcement text="Aura Effects - Extension v1.0\r--by Kent McCullough 2020 updated by SoxMax and bmos" font="emotefont" />
 
 	<base>
 		<string name="option_header_aura">Auras (GM)</string>

--- a/scripts/manager_effect_aura.lua
+++ b/scripts/manager_effect_aura.lua
@@ -235,17 +235,9 @@ local function auraOnMove(tokenMap)
 	if onMove then
 		onMove(tokenMap);
 	end
-	notifyPlayerMove(tokenMap);
-	--Debug.chat("finishing aura on move");
-end
-
-local function auraOnMove4e(tokenMap)
-	--Debug.chat("in auraOnMove4e")
-	if onMove then
-		onMove(tokenMap)
-	end
+	-- notifyPlayerMove(tokenMap);
 	updateAuras(tokenMap)
-	--Debug.chat("finishing aura on move")
+	--Debug.chat("finishing aura on move");
 end
 
 local updateAttributesFromToken = nil;
@@ -256,11 +248,7 @@ function auraUpdateAttributesFromToken(tokenMap)
 	end
 
 	onMove = tokenMap.onMove
-	if EffectManager4E then
-		tokenMap.onMove = auraOnMove4e
-	else
-		tokenMap.onMove = auraOnMove
-	end
+	tokenMap.onMove = auraOnMove
 end
 
 local function getDistanceBetweenCT(ctNodeSource, ctNodeTarget)
@@ -508,7 +496,7 @@ end
 local function handleExpireEffectSilent(msgOOB)
 	local nodeEffect = DB.findNode(msgOOB.sEffectNode);
 	if not nodeEffect then
-		ChatManager.SystemMessage(Interface.getString("ct_error_effectdeletefail") .. " (" .. msgOOB.sEffectNode .. ")");
+		-- ChatManager.SystemMessage(Interface.getString("ct_error_effectdeletefail") .. " (" .. msgOOB.sEffectNode .. ")");
 		return false;
 	end
 	local nodeActor = nodeEffect.getChild("...");

--- a/scripts/manager_effect_aura.lua
+++ b/scripts/manager_effect_aura.lua
@@ -235,8 +235,13 @@ local function auraOnMove(tokenMap)
 	if onMove then
 		onMove(tokenMap);
 	end
-	-- notifyPlayerMove(tokenMap);
-	updateAuras(tokenMap)
+	local imageControl = ImageManager.getImageControl(tokenMap)
+	-- Debug.chat(imageControl, imageControl.getTokenLockState())
+	if imageControl and imageControl.getTokenLockState() then
+		notifyPlayerMove(tokenMap)
+	else
+		updateAuras(tokenMap)
+	end
 	--Debug.chat("finishing aura on move");
 end
 

--- a/scripts/manager_effect_aura.lua
+++ b/scripts/manager_effect_aura.lua
@@ -236,8 +236,16 @@ local function auraOnMove(tokenMap)
 		onMove(tokenMap);
 	end
 	notifyPlayerMove(tokenMap);
-
 	--Debug.chat("finishing aura on move");
+end
+
+local function auraOnMove4e(tokenMap)
+	--Debug.chat("in auraOnMove4e")
+	if onMove then
+		onMove(tokenMap)
+	end
+	updateAuras(tokenMap)
+	--Debug.chat("finishing aura on move")
 end
 
 local updateAttributesFromToken = nil;
@@ -247,8 +255,12 @@ function auraUpdateAttributesFromToken(tokenMap)
 		updateAttributesFromToken(tokenMap);
 	end
 
-	onMove = tokenMap.onMove;
-	tokenMap.onMove = auraOnMove;
+	onMove = tokenMap.onMove
+	if EffectManager4E then
+		tokenMap.onMove = auraOnMove4e
+	else
+		tokenMap.onMove = auraOnMove
+	end
 end
 
 local function getDistanceBetweenCT(ctNodeSource, ctNodeTarget)
@@ -269,7 +281,7 @@ end
 
 function updateAuras(tokenMap)
 	--Debug.printstack();
-	--Debug.chat("updating Auras");
+	-- Debug.chat("updating Auras");
 	local sourceNode = CombatManager.getCTFromToken(tokenMap)
 	--if not nodeCT or not nodeCT.isOwner() then
 	if not sourceNode then
@@ -378,6 +390,7 @@ local function addAuraEffect(auraType, effect, targetNode, sourceNode)
 end
 
 function checkAuraApplicationAndAddOrRemove(sourceNode, targetNode, auraEffect, nodeInfo)
+	-- Debug.chat("Checking aura", auraEffect)
 	if not targetNode or not auraEffect then
 		return false
 	end
@@ -411,14 +424,13 @@ function checkAuraApplicationAndAddOrRemove(sourceNode, targetNode, auraEffect, 
 		if not nodeInfo.distanceBetween then
 			nodeInfo.distanceBetween = getDistanceBetweenCT(sourceNode, targetNode)
 		end
-		-- Debug.chat("distanceBetween", nodeInfo.distanceBetween, "nRange", nRange)
+		local existingAuraEffect = checkAuraAlreadyEffecting(sourceNode, targetNode, auraEffect)
+		-- Debug.chat("distanceBetween", nodeInfo.distanceBetween, "nRange", nRange, "existingAuraEffect", existingAuraEffect)
 		if nodeInfo.distanceBetween and nodeInfo.distanceBetween <= nRange then
-			local existingAuraEffect = checkAuraAlreadyEffecting(sourceNode, targetNode, auraEffect);
 			if not existingAuraEffect then
 				addAuraEffect(auraType, auraEffect, targetNode, sourceNode)
 			end
 		else
-			local existingAuraEffect = checkAuraAlreadyEffecting(sourceNode, targetNode, auraEffect);
 			if existingAuraEffect then
 				removeAuraEffect(auraType, existingAuraEffect)
 			end

--- a/scripts/manager_effect_aura.lua
+++ b/scripts/manager_effect_aura.lua
@@ -242,7 +242,7 @@ local function auraOnMove(tokenMap)
 	else
 		updateAuras(tokenMap)
 	end
-	--Debug.chat("finishing aura on move");
+	-- Debug.chat("finishing aura on move");
 end
 
 local updateAttributesFromToken = nil;
@@ -514,8 +514,11 @@ local function handleExpireEffectSilent(msgOOB)
 end
 
 function onInit()
-	updateAttributesFromToken = TokenManager.updateAttributesFromToken;
-	TokenManager.updateAttributesFromToken = auraUpdateAttributesFromToken;
+
+	onMove = Token.onMove
+	Token.onMove = auraOnMove
+	-- updateAttributesFromToken = TokenManager.updateAttributesFromToken;
+	-- TokenManager.updateAttributesFromToken = auraUpdateAttributesFromToken;
 
 	local DetectedEffectManager
 	if EffectManager35E then


### PR DESCRIPTION
Because of the change to `EffectManager.addEffect` the `bShowMsg` flag is now suppressing error messaging when applying effects. I've switch back from the OOB to directly calculating aura effects on the client and it seems to pretty reliably add/remove effects without any messaging when Silent Auras is on.

I tested on PFRPG and 4E.