### PR TITLE
Try to solve the empty effects by using less events per move in non token locking

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,25 @@
+{
+    "Lua.diagnostics.globals": [
+        "ActorManager",
+        "ChatManager",
+        "CombatManager",
+        "Comm",
+        "DB",
+        "Debug",
+        "EffectManager",
+        "EffectManager35E",
+        "EffectManager4E",
+        "EffectManager5E",
+        "ImageManager",
+        "Interface",
+        "OOBManager",
+        "OptionsManager",
+        "Session",
+        "Token",
+        "TokenManager",
+        "User"
+    ],
+    "Lua.diagnostics.disable": [
+        "lowercase-global"
+    ]
+}

--- a/scripts/manager_effect_aura.lua
+++ b/scripts/manager_effect_aura.lua
@@ -445,7 +445,7 @@ end
 
 function expireEffectSilent(nodeActor, nodeEffect, nExpireComp)
 	if not nodeEffect then
-		Debug.chat(nodeActor, nodeEffect, nExpireComp)
+		-- Debug.chat(nodeActor, nodeEffect, nExpireComp)
 		return false;
 	end
 
@@ -469,7 +469,7 @@ end
 function handleExpireEffectSilent(msgOOB)
 	local nodeEffect = DB.findNode(msgOOB.sEffectNode);
 	if not nodeEffect then
-		Debug.chat(msgOOB, nodeEffect)
+		-- Debug.chat(msgOOB, nodeEffect)
 		return false;
 	end
 	

--- a/scripts/manager_effect_aura.lua
+++ b/scripts/manager_effect_aura.lua
@@ -231,30 +231,15 @@ function customCheckConditional(rActor, nodeEffect, aConditions, rTarget, aIgnor
 	return bReturn;
 end
 
-local function getTokenLockState(tokenInstance)
-	if Session.IsHost then
-		return false
-	end
-	local ctrlImage = ImageManager.getImageControl(tokenInstance)
-	return ctrlImage and ctrlImage.getTokenLockState()
-end
-
 local onMove = nil;
 local function auraOnMove(tokenInstance)
 	if onMove then
 		onMove(tokenInstance);
 	end
-	if(getTokenLockState(tokenInstance)) then
+	if Session.IsHost then
+		-- Debug.chat("onMove aura update")
 		notifyTokenMove(tokenInstance)
 	end
-end
-
-local onDragEnd = nil
-local function auraOnDragEnd(tokenInstance, dragData)
-	if onDragEnd then
-		onDragEnd(tokenInstance, dragData)
-	end
-	notifyTokenMove(tokenInstance)
 end
 
 local function getRelationship(sourceNode, targetNode)
@@ -509,9 +494,6 @@ function onInit()
 
 	onMove = Token.onMove
 	Token.onMove = auraOnMove
-
-	onDragEnd = Token.onDragEnd
-	Token.onDragEnd = auraOnDragEnd
 
 	OOBManager.registerOOBMsgHandler(OOB_MSGTYPE_AURATOKENMOVE, handleTokenMovement);
 	OOBManager.registerOOBMsgHandler(OOB_MSGTYPE_AURAAPPLYSILENT, handleApplyEffectSilent);

--- a/scripts/manager_effect_aura.lua
+++ b/scripts/manager_effect_aura.lua
@@ -421,14 +421,15 @@ end
 
 function expireEffectSilent(nodeActor, nodeEffect, nExpireComp)
 	if not nodeEffect then
+		Debug.chat(nodeActor, nodeEffect, nExpireComp)
 		return false;
 	end
 
-	local bGMOnly = EffectManager.isGMEffect(nodeActor, nodeEffect);
-	local sEffect = DB.getValue(nodeEffect, aEffectVarMap["sName"]["sDBField"], "");
+	-- local bGMOnly = EffectManager.isGMEffect(nodeActor, nodeEffect);
 
 	-- Check for partial expiration
 	if (nExpireComp or 0) > 0 then
+		local sEffect = DB.getValue(nodeEffect, aEffectVarMap["sName"]["sDBField"], "");
 		local aEffectComps = parseEffect(sEffect);
 		if #aEffectComps > 1 then
 			table.remove(aEffectComps, nExpireComp);
@@ -444,6 +445,7 @@ end
 function handleExpireEffectSilent(msgOOB)
 	local nodeEffect = DB.findNode(msgOOB.sEffectNode);
 	if not nodeEffect then
+		Debug.chat(msgOOB, nodeEffect)
 		return false;
 	end
 	
@@ -488,5 +490,5 @@ function onInit()
 	OOBManager.registerOOBMsgHandler(OOB_MSGTYPE_AURAAPPLYSILENT, handleApplyEffectSilent);
 	OOBManager.registerOOBMsgHandler(OOB_MSGTYPE_AURAEXPIRESILENT, handleExpireEffectSilent);
 	
-	OptionsManager.registerOption2("AURASILENT", false, "option_header_aura", "option_label_AURASILENT", "option_entry_cycler", { labels = "option_val_friend|option_val_foe|option_val_all", values="friend|foe|all", baselabel = "option_val_off", baseval="off", default="friend"});
+	OptionsManager.registerOption2("AURASILENT", false, "option_header_aura", "option_label_AURASILENT", "option_entry_cycler", { labels = "option_val_friend|option_val_foe|option_val_all", values="friend|foe|all", baselabel = "option_val_off", baseval="off", default="all"});
 end

--- a/scripts/manager_effect_aura.lua
+++ b/scripts/manager_effect_aura.lua
@@ -250,9 +250,9 @@ local function auraOnMove(tokenInstance)
 end
 
 local onDragEnd = nil
-local function auraOnDragEnd(tokenInstance, dragdata)
+local function auraOnDragEnd(tokenInstance, dragData)
 	if onDragEnd then
-		onDragEnd(target, dragdata)
+		onDragEnd(tokenInstance, dragData)
 	end
 	notifyTokenMove(tokenInstance)
 end

--- a/scripts/manager_effect_aura.lua
+++ b/scripts/manager_effect_aura.lua
@@ -231,12 +231,30 @@ function customCheckConditional(rActor, nodeEffect, aConditions, rTarget, aIgnor
 	return bReturn;
 end
 
-local onMove = nil;
-local function auraOnMove(tokenMap)
-	if onMove then
-		onMove(tokenMap);
+local function getTokenLockState(tokenInstance)
+	if Session.IsHost then
+		return false
 	end
-	notifyTokenMove(tokenMap)
+	local ctrlImage = ImageManager.getImageControl(tokenInstance)
+	return ctrlImage and ctrlImage.getTokenLockState()
+end
+
+local onMove = nil;
+local function auraOnMove(tokenInstance)
+	if onMove then
+		onMove(tokenInstance);
+	end
+	if(getTokenLockState(tokenInstance)) then
+		notifyTokenMove(tokenInstance)
+	end
+end
+
+local onDragEnd = nil
+local function auraOnDragEnd(tokenInstance, dragdata)
+	if onDragEnd then
+		onDragEnd(target, dragdata)
+	end
+	notifyTokenMove(tokenInstance)
 end
 
 local function getRelationship(sourceNode, targetNode)
@@ -491,6 +509,9 @@ function onInit()
 
 	onMove = Token.onMove
 	Token.onMove = auraOnMove
+
+	onDragEnd = Token.onDragEnd
+	Token.onDragEnd = auraOnDragEnd
 
 	OOBManager.registerOOBMsgHandler(OOB_MSGTYPE_AURATOKENMOVE, handleTokenMovement);
 	OOBManager.registerOOBMsgHandler(OOB_MSGTYPE_AURAAPPLYSILENT, handleApplyEffectSilent);


### PR DESCRIPTION
I've inconsistently reproduced the empty effect lines problem from issue #9 . To the best of my knowledge it seems to be something to do with networking and rapid/many moves. So far I haven't been able to reproduce with this change which uses the onDragEnd event for tokens when Token Locking is disabled. This generates a single event to process when a token's "move" has finished.

The drawback to this is of course also you don't see auras applied/removed until your move is completed as well.