### PR TITLE
Support for nameless auras

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This extension is not currently compatible with SilentRuin's [Polymorphism Exten
 ### AURA Effect
 ```AURA: 10 friend; Aura of Protection; SAVE: 5```
 
-A name is required (such as Aura of Protection in the above example) or it will not work.
-
 This will add a 10 foot aura around the person who has this effect.
 
-Allies within 10' will receive an effect "FROMAURA: Aura of Protection; SAVE: 5".
+Allies within 10' will receive an effect "FROMAURA; Aura of Protection; SAVE: 5".
+
+While a name (such as 'Aura of Protection' in the above example) is not required it is highly reccomended to help avoid collisions between effects.
 
 The bearer of the AURA effect will also receive its benefits.
 
@@ -44,7 +44,7 @@ You can also use the "!" operator in a FACTION conditional to reverse the result
 
 This will add a 10 foot aura around the person who has this effect.
 
-Anyone within 10' will receive an effect "FROMAURA: Test; IF: FACTION(!foe); ATK: -5".
+Anyone within 10' will receive an effect "FROMAURA; Test; IF: FACTION(!foe); ATK: -5".
 
 Although the effect will be visible on all actors within 10', the penalty will only be applied to people who are not specifically foes.
 

--- a/scripts/manager_effect_aura.lua
+++ b/scripts/manager_effect_aura.lua
@@ -462,6 +462,22 @@ function handleExpireEffectSilent(msgOOB)
 	expireEffectSilent(nodeActor, nodeEffect, tonumber(msgOOB.nExpireClause) or 0);
 end
 
+-- This shouldn't remain long term
+local function replaceOldFromAuraString()
+	if Session.IsHost then
+		for _, nodeCT in pairs(CombatManager.getCombatantNodes()) do
+			for _, nodeEffect in pairs(DB.getChildren(nodeCT, "effects")) do
+				local sLabelNodeEffect = DB.getValue(nodeEffect, aEffectVarMap["sName"]["sDBField"], "")
+				local index = string.find(sLabelNodeEffect, "FROMAURA:", 0, true)
+				if index and index == 1 then
+					-- Debug.console(sLabelNodeEffect, index)
+					DB.setValue(nodeEffect, aEffectVarMap["sName"]["sDBField"], "string", fromAuraString .. sLabelNodeEffect:sub(10))
+				end
+			end
+		end
+	end
+end
+
 function onInit()
 	CombatManager.setCustomDeleteCombatantEffectHandler(checkDeletedAuraEffects);
 	if Session.IsHost then
@@ -469,7 +485,7 @@ function onInit()
 		DB.addHandler(DB.getPath("combattracker.list.*.effects.*.isactive"), "onUpdate", onEffectChanged)
 		DB.addHandler(DB.getPath("combattracker.list.*.effects.*.isgmonly"), "onUpdate", onEffectChanged)
 	end
-	
+
 	local DetectedEffectManager
 	if EffectManager35E then
 		DetectedEffectManager = EffectManager35E
@@ -493,6 +509,8 @@ function onInit()
 	OOBManager.registerOOBMsgHandler(OOB_MSGTYPE_AURATOKENMOVE, handleTokenMovement);
 	OOBManager.registerOOBMsgHandler(OOB_MSGTYPE_AURAAPPLYSILENT, handleApplyEffectSilent);
 	OOBManager.registerOOBMsgHandler(OOB_MSGTYPE_AURAEXPIRESILENT, handleExpireEffectSilent);
-	
+
 	OptionsManager.registerOption2("AURASILENT", false, "option_header_aura", "option_label_AURASILENT", "option_entry_cycler", { labels = "option_val_friend|option_val_foe|option_val_all", values="friend|foe|all", baselabel = "option_val_off", baseval="off", default="all"});
+
+	replaceOldFromAuraString()
 end

--- a/scripts/manager_effect_aura.lua
+++ b/scripts/manager_effect_aura.lua
@@ -7,7 +7,7 @@ OOB_MSGTYPE_AURATOKENMOVE = "aurasontokenmove";
 OOB_MSGTYPE_AURAAPPLYSILENT = "applyeffsilent";
 OOB_MSGTYPE_AURAEXPIRESILENT = "expireeffsilent";
 
-local fromAuraString = "FROMAURA:"
+local fromAuraString = "FROMAURA;"
 local auraString = "AURA:"
 
 local aEffectVarMap = {


### PR DESCRIPTION
Figured I'd open a PR for this so we can discuss. By changing the `:` to a `;` nameless auras shouldn't be a problem. However I agree it does increase the chance that they'll collide with raw effects if there's no name.

Another change we could do is make the aura name be a required part of our `AURA:` definition.

Also we could just document that you need a name after the `AURA:` block as well and leave it be.