### PR TITLE
Movefilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ You can also use the "!" or "~" operators in a FACTION conditional to reverse th
 
 ```AURA: 10 all; Speed Bonus for All, Attack Bonus for Blank Factions; SPEED: 20; IF: FACTION(faction); ATK: 2```
 
+### Special AURA type CUBE
+Default auras are spheres. A cube shaped aura can be defined by adding **cube** to the aura filter as shown in the example below. The length of the side of the cube is defined by the aura value. In the case of the example, the length of a side of the cube aura is 10.
+
+```AURA: 10 all,cube; ATK: -5```
 ### Special AURA type SINGLE
 There are a number of spells and effects, particularly in the 5E ruleset, which necessitate a slightly different aura behavior. These have the text or something similar *"When the creature enters the area for the first time on a turn or starts its turn there"*. This behavior can be enabled by adding **single** to the aura filter as shown in the example below. The aura will be applied to the target only when the target starts its turn in the aura or enters (moves into) the area for the first time on a turn. It will not be reapplied if the target leaves the area and returns on the same turn.
 

--- a/effect_builder/effects/scripts/AURA.lua
+++ b/effect_builder/effects/scripts/AURA.lua
@@ -1,9 +1,10 @@
--- luacheck: globals createEffectString parentcontrol number_value effect_faction effect_auraSingle
+-- luacheck: globals createEffectString parentcontrol number_value effect_faction effect_auraSingle effect_auraCube
 
 function createEffectString()
 	local effectString = parentcontrol.window.effect.getStringValue() .. ': ' .. number_value.getStringValue()
 	if not effect_faction.isEmpty() then effectString = effectString .. ' ' .. effect_faction.getStringValue() end
 
 	if not effect_faction.isEmpty() and effect_auraSingle.getValue() > 0 then effectString = effectString .. ',single' end
+	if not effect_faction.isEmpty() and effect_auraCube.getValue() > 0 then effectString = effectString .. ',cube' end
 	return effectString
 end

--- a/effect_builder/strings/strings_effect_editor.xml
+++ b/effect_builder/strings/strings_effect_editor.xml
@@ -8,5 +8,6 @@
 <root version="3.0">
     <string name="conditional_aura_faction">Faction</string>
     <string name="effect_auraSingle">Type Single</string>
+    <string name="effect_auraCube">Type Cube</string>
     <string name="effect_aura">Aura</string>
 </root>

--- a/extension.xml
+++ b/extension.xml
@@ -34,6 +34,7 @@
 		<script name="AuraEffectTriggers" file="scripts/aura_triggers.lua" />
 		<script name="AuraEffectSilencer" file="scripts/silent_auras.lua" />
 		<script name="AuraFactionConditional" file="scripts/faction_conditional.lua" />
+		<script name="AuraToken" file="scripts/manager_token_aura.lua" />
 
 		<icon name="aura_icon" file="graphics/aura_icon.png" />
 

--- a/extension.xml
+++ b/extension.xml
@@ -35,6 +35,7 @@
 		<script name="AuraEffectSilencer" file="scripts/silent_auras.lua" />
 		<script name="AuraFactionConditional" file="scripts/faction_conditional.lua" />
 		<script name="AuraToken" file="scripts/manager_token_aura.lua" />
+		<script name="AuraTracker" file="scripts/manager_aura_tracker.lua" />
 
 		<icon name="aura_icon" file="graphics/aura_icon.png" />
 

--- a/scripts/aura_triggers.lua
+++ b/scripts/aura_triggers.lua
@@ -56,14 +56,18 @@ function handleTokenMovement(msgOOB)
 	local time1 = nil
 	if bDebugPerformance then time1 = os.clock() end
 	local _, winImage = ImageManager.getImageControl(CombatManager.getTokenFromCT(msgOOB.sCTNode))
-	updateAurasForMap(winImage,DB.findNode(msgOOB.sCTNode))
-	if bDebugPerformance then
-		sTime = string.format('%s%s,', sTime, tostring(os.clock() - time1))
-		Debug.console(sTime)
+	if AuraToken.isMovedFilter(DB.findNode(msgOOB.sCTNode),CombatManager.getTokenFromCT(msgOOB.sCTNode)) then
+		updateAurasForMap(winImage,DB.findNode(msgOOB.sCTNode))
+		if bDebugPerformance then
+			sTime = string.format('%s%s,', sTime, tostring(os.clock() - time1))
+			Debug.console(sTime)
+		end
 	end
 end
 
----	This function requests aura processing to be performed on the host FG instance.
+
+
+	---	This function requests aura processing to be performed on the host FG instance.
 function notifyTokenMove(token)
 	local nodeCT = CombatManager.getCTFromToken(token)
 	if not nodeCT then return end

--- a/scripts/manager_aura_tracker.lua
+++ b/scripts/manager_aura_tracker.lua
@@ -1,0 +1,81 @@
+--
+--	Please see the LICENSE.md file included with this distribution for attribution and copyright information.
+--
+
+-- luacheck: globals getAllTrackedAuras addTrackedAura getTrackedAuras deleteTrackedAuras removeTrackedAura
+-- luacheck: globals addTrackedFromAura getTrackedFromAuras removeTrackedFromAura printTrackedAuras
+
+-- Constructed as such [sSourceNode][sAuraNode][sFromAuraNode]
+-- [sSourceNode] - Array of nodeCT paths of the token who has an aura effect
+-- [sAuraNode] - Array of effect paths of the auras which are on the [sSourceNode]
+-- [sFromAuraNode] - Array of nodeCT paths which [sAuraNode] is affecting with FROMAURA
+local tActiveAuras = {}
+
+function onInit()
+    -- Comm.registerSlashHandler("aura", printTrackedAuras);
+end
+
+function getAllTrackedAuras()
+    return UtilityManager.copyDeep(tActiveAuras)
+end
+
+function addTrackedAura(sSourceNode, sAuraNode)
+    if not tActiveAuras[sSourceNode] then
+        tActiveAuras[sSourceNode] = {}
+    end
+    if not tActiveAuras[sSourceNode][sAuraNode] then
+        tActiveAuras[sSourceNode][sAuraNode] = {}
+    end
+end
+
+function getTrackedAuras(sSourceNode)
+    local aReturn = {}
+    if tActiveAuras[sSourceNode] then
+        aReturn = UtilityManager.copyDeep(tActiveAuras[sSourceNode])
+    end
+    return aReturn
+end
+
+function deleteTrackedAuras(sSourceNode)
+    tActiveAuras[sSourceNode] = nil
+end
+
+function removeTrackedAura(sSourceNode, sAuraNode)
+    if tActiveAuras[sSourceNode] and tActiveAuras[sSourceNode][sAuraNode] then
+        tActiveAuras[sSourceNode][sAuraNode] = nil
+    end
+    if tActiveAuras[sSourceNode] and not next(tActiveAuras[sSourceNode]) then
+        tActiveAuras[sSourceNode] = nil
+    end
+end
+
+function addTrackedFromAura(sSourceNode, sAuraNode, sFromAuraNode)
+    addTrackedAura(sSourceNode, sAuraNode)
+    if not tActiveAuras[sSourceNode][sAuraNode][sFromAuraNode] then
+        tActiveAuras[sSourceNode][sAuraNode][sFromAuraNode] = true
+    end
+end
+
+function getTrackedFromAuras(sSourceNode, sAuraNode)
+    local aReturn = {}
+    if tActiveAuras[sSourceNode] and tActiveAuras[sSourceNode][sAuraNode] then
+        aReturn = UtilityManager.copyDeep(tActiveAuras[sSourceNode][sAuraNode])
+    end
+    return aReturn
+end
+
+function removeTrackedFromAura(sSourceNode, sAuraNode, sFromAuraNode)
+    if sFromAuraNode then
+        if tActiveAuras[sSourceNode] and tActiveAuras[sSourceNode][sAuraNode] then
+            tActiveAuras[sSourceNode][sAuraNode][sFromAuraNode] = nil
+        end
+    else
+        if tActiveAuras[sSourceNode] and tActiveAuras[sSourceNode][sAuraNode] then
+            tActiveAuras[sSourceNode][sAuraNode] = {}
+        end
+    end
+end
+
+function printTrackedAuras()
+    Debug.chat(tActiveAuras)
+end

--- a/scripts/manager_token_aura.lua
+++ b/scripts/manager_token_aura.lua
@@ -2,6 +2,7 @@
 --	Please see the LICENSE.md file included with this distribution for attribution and copyright information.
 --
 -- luacheck: globals add delete customLinkToken onAdd onDelete isMovedFilter getTokensWithinCube
+-- luacheck: globals Image.getGridSize Image.hasGrid Image.getDistanceBaseUnits
 local tImages = {}
 local linkToken = nil
 

--- a/scripts/manager_token_aura.lua
+++ b/scripts/manager_token_aura.lua
@@ -1,0 +1,99 @@
+local tImages = {}
+
+local linkToken = nil
+
+function onInit()
+    if Session.IsHost then
+        Token.addEventHandler('onDelete', onDelete)
+
+        linkToken = TokenManager.linkToken
+        TokenManager.linkToken = customLinkToken
+    end
+end
+
+function onClose()
+    if Session.IsHost then
+        TokenManager.linkToken = linkToken
+    end
+end
+
+function add(nodeCT)
+    onAdd(CombatManager.getTokenFromCT(nodeCT))
+end
+
+function delete(nodeCT)
+    onDelete(CombatManager.getTokenFromCT(nodeCT))
+end
+
+-- Workaround because Token.onAdd, the token isn't linked to the CT node yet via FG.
+-- Let FG do its thing they we can track things properly
+function customLinkToken(nodeCT, newTokenInstance)
+    linkToken(nodeCT, newTokenInstance)
+    onAdd(CombatManager.getTokenFromCT(nodeCT))
+end
+
+function onAdd(token)
+    if token then
+        local nodeImage = token.getContainerNode()
+        local sImagePath = DB.getPath(nodeImage)
+        if not tImages[sImagePath] then
+            tImages[sImagePath] = {nGridSize = Image.getGridSize(nodeImage), tTokens = {}}
+        end
+        local nodeCT = CombatManager.getCTFromToken(token)
+        if nodeCT then
+            local sNodePath = DB.getPath(nodeCT)
+            local nX, nY = token.getPosition()
+            local nZ = token.getHeight()
+            tImages[sImagePath].tTokens[sNodePath] = {nX = nX, nY = nY, nZ = nZ}
+        end
+    end
+end
+
+function onDelete(token)
+    if token then
+        local nodeImage = token.getContainerNode()
+        local sImagePath = DB.getPath(nodeImage)
+        if tImages[sImagePath] then
+            local nodeCT = CombatManager.getCTFromToken(token)
+            if nodeCT then
+                if tImages[sImagePath].tTokens[nodeCT] then
+                    tImages[sImagePath].tTokens[nodeCT] = nil
+                    if not next(tImages[sImagePath].tTokens) then
+                        tImages[sImagePath] = nil
+                    end
+                end
+            end
+        end
+    end
+end
+
+-- Although the token is marked as moved, for performance reasons it needs to move more than the
+-- threshold distance (at least half of grid size rounded down) to count as moved
+function isMovedFilter(nodeCT, token)
+    local bReturn = false
+    local nodeImage = token.getContainerNode()
+    local sImagePath = DB.getPath(nodeImage)
+
+    if tImages[sImagePath] and nodeCT and Image.hasGrid(sImagePath) then
+        local sNodePath = DB.getPath(nodeCT)
+        local nThreshold = (math.floor(tImages[sImagePath].nGridSize - 1) / 2)
+        local nX, nY = token.getPosition()
+        local nZ = token.getHeight()
+
+        if tImages[sImagePath].tTokens[sNodePath] then
+            if math.abs(tImages[sImagePath].tTokens[sNodePath].nX - nX) > nThreshold or
+               math.abs(tImages[sImagePath].tTokens[sNodePath].nY - nY) > nThreshold then
+                tImages[sImagePath].tTokens[sNodePath].nX = nX
+                tImages[sImagePath].tTokens[sNodePath].nY = nY
+                tImages[sImagePath].tTokens[sNodePath].nZ = nZ
+                bReturn = true
+            end
+        else
+            tImages[sImagePath].tTokens[sNodePath].nX = nX
+            tImages[sImagePath].tTokens[sNodePath].nY = nY
+            tImages[sImagePath].tTokens[sNodePath].nZ = nZ
+            bReturn = true
+        end
+    end
+    return bReturn
+end

--- a/scripts/silent_auras.lua
+++ b/scripts/silent_auras.lua
@@ -96,7 +96,7 @@ function notifyApplySilent(rEffect, vTargets)
 end
 
 function notifyApply(rEffect, targetNodePath)
-	if checkSilentNotification(rEffect.sSource, targetNodePath) then
+	if rEffect and checkSilentNotification(rEffect.sSource, targetNodePath) then
 		notifyApplySilent(rEffect, targetNodePath)
 	else
 		EffectManager.notifyApply(rEffect, targetNodePath)


### PR DESCRIPTION
Fixes the B9 Spell Tokens issue with single aura type
Added ability to define a Cube aura
Added some aura tracking so that the overabundance of searching nodes for effects that end up fruitless is greatly reduced. Should see performance gains especially for situations where there are a lot of CT actors and/or lots of effects in the CT. I don't have any numbers on the gains however.

There was also a second aura type in issue #16 about not falling off when out of range. I don't know the use case for that so I don't really understand the ask.